### PR TITLE
Fix formatting, resolve namespace errors

### DIFF
--- a/managers/ElementManager.py
+++ b/managers/ElementManager.py
@@ -1,57 +1,164 @@
 # coding: utf-8
-from os import listdir
-from os.path import isfile, join, splitext
+import os
+# from os import listdir # -> Is not an issue however it is neater to just import os
+# from os.path import isfile, join, splitext # --> join is a builtin method causing name space issues
 from importlib import import_module
 import sys
 sys.path.append('elements')
 
-class ElementManager (object):
-	elementsFolder = 'elements'
-	elementExclusionList = ('ElementBase.py','__init__.py','Template.py')
-	requiredElementInstanceMethods = ('get_status','get_input','get_output','get_input_type','get_output_type','get_params','set_params','get_description','get_title','get_category','get_icon','run')
-	
-	def get_all_elements(self, type=''):
-		elements = [splitext(f) for f in listdir(self.elementsFolder) if isfile(join(self.elementsFolder, f)) and not f in self.elementExclusionList]
-		validElements = []
-		invalidElements = []
-		for i in elements:
-			mod = import_module(i[0])
-			reload(mod)
-			cla = getattr(mod,i[0])
-			try:
-				for method in self.requiredElementInstanceMethods:
-					getattr(cla(), method)
-				validElements.append(cla())
-			except (NotImplementedError, AttributeError):
-				invalidElements.append(cla())
 
-		if type == '':
-			return {'valid':validElements, 'invalid':invalidElements}
-		elif type == 'valid':
-			return validElements
-		elif type == 'invalid':
-			return inValidElements
-		else:
-			return []	
-		
-	def get_element_class(self, element):
-		return type(element).__name__
-	
-	def get_element_with_title(self, title):
-		elements = self.get_all_elements('valid')
-		for element in elements:
-			if element.get_title() == title:
-				return element
-		return None
-	
-	def create_element(self, title):
-		titleValidated = title.replace(" ","")
-		templatePath = self.elementsFolder + '/Template.py'
-		f = open(templatePath, 'r')
-		tem = f.read()
-		tem = tem.replace("{{title}}",titleValidated)
-		tem = tem.replace("{{title_space}}",title)
-		f.close()
-		f = open(self.elementsFolder+'/'+titleValidated+'.py','w')
-		f.write(tem)
-		f.close()
+class ElementManager (object):
+    elementsFolder = 'elements'
+    elementExclusionList = ('ElementBase.py','__init__.py','Template.py')
+    requiredElementInstanceMethods = (
+                                        'get_status', 'get_input', 'get_output',
+                                        'get_input_type', 'get_output_type', 'get_params',
+                                        'set_params', 'get_description', 'get_title',
+                                        'get_category', 'get_icon', 'run')
+
+    def get_all_elements(self, element_type=None):
+        elements = [
+                        os.path.splitext(f) for f in os.listdir(self.elementsFolder)
+                        if os.path.isfile(os.path.join(self.elementsFolder, f)) and
+                        not f in self.elementExclusionList
+                    ]
+        validElements = []
+        invalidElements = []
+        for i in elements:
+            mod = import_module(i[0])
+            reload(mod)
+            klass = getattr(mod,i[0])
+            klassIsValid = True
+            for method in self.requiredElementInstanceMethods:
+                if not hasattr(klass, method):
+                    klassIsValid = False
+                    break
+            if klassIsValid:
+                validElements.append(klass())
+            else:
+                invalidElements.append(klass())
+
+        if not element_type:
+            return {'valid':validElements, 'invalid':invalidElements}
+        elif element_type == 'valid':
+            return validElements
+        elif element_type == 'invalid':
+            return inValidElements
+        else:
+            return []
+
+    def get_element_class(self, element):
+        # The element class is element.__class__
+        return element.__class__.__name__
+
+    def get_element_with_title(self, title):
+        elements = self.get_all_elements('valid')
+        for element in elements:
+            if element.get_title() == title:
+                return element
+        return None
+
+    def create_element(self, title):
+        titleValidated = title.replace(" ","")
+        templatePath = os.path.join(self.elementsFolder, 'Template.py')
+        elementPath = os.path.join(self.elementsFolder, "{fileName}.py".format(fileName=titleValidated))
+        if os.path.isfile(elementPath):
+            print 'Element Already Exists'
+            return
+        with open(templatePath, 'r') as f:
+            # str.format thinks that on line 8 ```self.params = {}``` and
+            # on line 27 ```def set_params(self, params = {})``` are fomatting values
+            tem = f.read().format(*['{}', '{}'], **{'title':titleValidated, 'title_space':title})
+        with open(elementPath, 'w') as f:
+            f.write(tem)
+            
+        
+if __name__ == '__main__':
+    sys.path[-1] = '../elements'
+    ElementManager.elementsFolder = '../elements'
+    manager = ElementManager()
+    print manager.get_all_elements()
+    print manager.get_element_with_title('newElement')
+    manager.create_element('newElement1')
+# coding: utf-8
+import os
+# from os import listdir # -> Is not an issue however it is neater to just import os
+# from os.path import isfile, join, splitext # --> join is a builtin method causing name space issues
+from importlib import import_module
+import sys
+sys.path.append('elements')
+
+
+class ElementManager (object):
+    elementsFolder = 'elements'
+    elementExclusionList = ('ElementBase.py','__init__.py','Template.py')
+    requiredElementInstanceMethods = (
+                                        'get_status', 'get_input', 'get_output',
+                                        'get_input_type', 'get_output_type', 'get_params',
+                                        'set_params', 'get_description', 'get_title',
+                                        'get_category', 'get_icon', 'run')
+
+    def get_all_elements(self, element_type=None):
+        elements = [
+                        os.path.splitext(f) for f in os.listdir(self.elementsFolder)
+                        if os.path.isfile(os.path.join(self.elementsFolder, f)) and
+                        not f in self.elementExclusionList
+                    ]
+        validElements = []
+        invalidElements = []
+        for i in elements:
+            mod = import_module(i[0])
+            reload(mod)
+            klass = getattr(mod,i[0])
+            klassIsValid = True
+            for method in self.requiredElementInstanceMethods:
+                if not hasattr(klass, method):
+                    klassIsValid = False
+                    break
+            if klassIsValid:
+                validElements.append(klass())
+            else:
+                invalidElements.append(klass())
+
+        if not element_type:
+            return {'valid':validElements, 'invalid':invalidElements}
+        elif element_type == 'valid':
+            return validElements
+        elif element_type == 'invalid':
+            return inValidElements
+        else:
+            return []
+
+    def get_element_class(self, element):
+        # The element class is element.__class__
+        return element.__class__.__name__
+
+    def get_element_with_title(self, title):
+        elements = self.get_all_elements('valid')
+        for element in elements:
+            if element.get_title() == title:
+                return element
+        return None
+
+    def create_element(self, title):
+        titleValidated = title.replace(" ","")
+        templatePath = os.path.join(self.elementsFolder, 'Template.py')
+        elementPath = os.path.join(self.elementsFolder, "{fileName}.py".format(fileName=titleValidated))
+        if os.path.isfile(elementPath):
+            print 'Element Already Exists'
+            return
+        with open(templatePath, 'r') as f:
+            # str.format thinks that on line 8 ```self.params = {}``` and
+            # on line 27 ```def set_params(self, params = {})``` are fomatting values
+            tem = f.read().format(*['{}', '{}'], **{'title':titleValidated, 'title_space':title})
+        with open(elementPath, 'w') as f:
+            f.write(tem)
+            
+        
+if __name__ == '__main__':
+    sys.path[-1] = '../elements'
+    ElementManager.elementsFolder = '../elements'
+    manager = ElementManager()
+    print manager.get_all_elements()
+    print manager.get_element_with_title('newElement')
+    manager.create_element('newElement1')


### PR DESCRIPTION
Changed some imports to resolve namespace related errors namely the join function. Python has str.join which was being overridden by os.path.join
Fix the layout to be easier to read especially on smaller screens
Made create_element method a little bit 'safer' to use.

Useful links:
[https://pyformat.info/](https://pyformat.info/)
[http://effbot.org/zone/python-with-statement.htm](http://effbot.org/zone/python-with-statement.htm)
